### PR TITLE
bug fix for querying here(up(someKey))

### DIFF
--- a/design/craft/src/config/Config.scala
+++ b/design/craft/src/config/Config.scala
@@ -93,7 +93,7 @@ object config {
 
   private class PartialParameters(f: (View, View, View) => PartialFunction[Any,Any]) extends Parameters {
     protected[config] def chain[T](site: View, tail: View, pname: Field[T]) = {
-      val g = f(site, this, tail)
+      val g = f(site, new ChainView(this, tail), tail)
       if (g.isDefinedAt(pname)) Some(g.apply(pname).asInstanceOf[T]) else tail.find(pname, site)
     }
   }


### PR DESCRIPTION
```
    object K0 extends Field[String]("K0Default")
    object K1 extends Field[String]
    val pf0: (View, View, View) => PartialFunction[Any, Any] =
      (site: View, here: View, up: View) => {
        case K0 => "V0"
      }
    val pf1: (View, View, View) => PartialFunction[Any, Any] =
      (site: View, here: View, up: View) => {
        case K0 => up(K0)
        case K1 => here(K0)
      }

      assert(Parameters(pf0).alter(Parameters(pf1)).lift(K1).contains("V0"))
```
Before this PR, this query will `Parameters(pf0).alter(Parameters(pf1)).lift(K1) == Some("K0Default")`