### PR TITLE
Add src to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build-rules/sbt/project/target/
 build-rules/sbt/target/
 build-rules/mill/out/
+src
 *.swp
 *~


### PR DESCRIPTION
In Chipyard builds,`src` is generated and not in `.gitignore`; this keeps the submodule from having untracked content after a build. I'm not sure if this issue is specific to Chipyard or a general problem.